### PR TITLE
Fix LVGL nav timeout and implement async screen loader

### DIFF
--- a/main/application/auth_manager.c
+++ b/main/application/auth_manager.c
@@ -1,0 +1,74 @@
+#include "application/auth_manager.h"
+
+#include <stdbool.h>
+#include <string.h>
+
+#include "esp_log.h"
+
+static const char *TAG = "auth_manager";
+
+typedef struct
+{
+    const hmi_system_config_t *config;
+    hmi_role_t current_role;
+    bool logged_in;
+} auth_manager_context_t;
+
+static auth_manager_context_t s_auth_manager;
+
+esp_err_t auth_manager_init(const hmi_system_config_t *config)
+{
+    if (config == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    (void)memset(&s_auth_manager, 0, sizeof(s_auth_manager));
+    s_auth_manager.config = config;
+    s_auth_manager.current_role = HMI_ROLE_OPERATOR;
+    ESP_LOGI(TAG, "Initialized with default role=%d", (int)s_auth_manager.current_role);
+    return ESP_OK;
+}
+
+void auth_manager_deinit(void)
+{
+    (void)memset(&s_auth_manager, 0, sizeof(s_auth_manager));
+}
+
+esp_err_t auth_manager_login_password(const char *user_name, const char *password, hmi_role_t requested_role)
+{
+    if ((user_name == NULL) || (password == NULL) || (s_auth_manager.config == NULL)) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    s_auth_manager.logged_in = true;
+    s_auth_manager.current_role = requested_role;
+    return ESP_OK;
+}
+
+void auth_manager_logout(void)
+{
+    s_auth_manager.logged_in = false;
+    s_auth_manager.current_role = HMI_ROLE_OPERATOR;
+}
+
+hmi_role_t auth_manager_get_role(void)
+{
+    return s_auth_manager.current_role;
+}
+
+bool auth_manager_has_permission(uint32_t permission_mask)
+{
+    uint32_t index;
+
+    if (s_auth_manager.config == NULL) {
+        return false;
+    }
+
+    for (index = 0U; index < s_auth_manager.config->role_count; index++) {
+        if (s_auth_manager.config->role_definitions[index].role_id == s_auth_manager.current_role) {
+            return ((s_auth_manager.config->role_definitions[index].permissions & permission_mask) != 0U);
+        }
+    }
+
+    return false;
+}

--- a/main/bsp/display/display_lvgl.c
+++ b/main/bsp/display/display_lvgl.c
@@ -1,0 +1,337 @@
+#include "bsp/display/display_lvgl.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "driver/spi_master.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#include "bsp/board_config.h"
+#include "config/system_config.h"
+#include "ui/ui_manager.h"
+#include "utils/lvgl_lock.h"
+
+static const char *TAG = "display_lvgl";
+
+static bool notify_lvgl_flush_ready(esp_lcd_panel_io_handle_t panel_io,
+                                    esp_lcd_panel_io_event_data_t *event_data,
+                                    void *user_ctx)
+{
+    lv_display_t *display = (lv_display_t *)user_ctx;
+
+    LV_UNUSED(panel_io);
+    LV_UNUSED(event_data);
+
+    if (display != NULL) {
+        lv_display_flush_ready(display);
+    }
+
+    return false;
+}
+
+static esp_err_t apply_display_rotation(display_lvgl_t *context, lv_display_t *display)
+{
+    esp_err_t result = ESP_OK;
+    lv_display_rotation_t rotation;
+
+    if ((context == NULL) || (display == NULL)) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    rotation = lv_display_get_rotation(display);
+    if (rotation == context->applied_rotation) {
+        return ESP_OK;
+    }
+
+    switch (rotation) {
+    case LV_DISPLAY_ROTATION_0:
+        result = esp_lcd_panel_swap_xy(context->panel_handle, false);
+        if (result == ESP_OK) {
+            result = esp_lcd_panel_mirror(context->panel_handle, true, false);
+        }
+        break;
+    case LV_DISPLAY_ROTATION_90:
+        result = esp_lcd_panel_swap_xy(context->panel_handle, true);
+        if (result == ESP_OK) {
+            result = esp_lcd_panel_mirror(context->panel_handle, true, true);
+        }
+        break;
+    case LV_DISPLAY_ROTATION_180:
+        result = esp_lcd_panel_swap_xy(context->panel_handle, false);
+        if (result == ESP_OK) {
+            result = esp_lcd_panel_mirror(context->panel_handle, false, true);
+        }
+        break;
+    case LV_DISPLAY_ROTATION_270:
+        result = esp_lcd_panel_swap_xy(context->panel_handle, true);
+        if (result == ESP_OK) {
+            result = esp_lcd_panel_mirror(context->panel_handle, false, false);
+        }
+        break;
+    default:
+        result = ESP_ERR_INVALID_STATE;
+        break;
+    }
+
+    if (result == ESP_OK) {
+        context->applied_rotation = rotation;
+    }
+
+    return result;
+}
+
+static void display_lvgl_flush_cb(lv_display_t *display, const lv_area_t *area, uint8_t *pixel_map)
+{
+    display_lvgl_t *context = (display_lvgl_t *)lv_display_get_user_data(display);
+    const int32_t offset_x1 = area->x1;
+    const int32_t offset_x2 = area->x2;
+    const int32_t offset_y1 = area->y1;
+    const int32_t offset_y2 = area->y2;
+
+    if ((context == NULL) || (pixel_map == NULL)) {
+        return;
+    }
+
+    (void)apply_display_rotation(context, display);
+    lv_draw_sw_rgb565_swap(pixel_map,
+                           (uint32_t)(offset_x2 + 1 - offset_x1) *
+                           (uint32_t)(offset_y2 + 1 - offset_y1));
+    (void)esp_lcd_panel_draw_bitmap(context->panel_handle,
+                                    offset_x1,
+                                    offset_y1,
+                                    offset_x2 + 1,
+                                    offset_y2 + 1,
+                                    pixel_map);
+}
+
+static void display_lvgl_touch_cb(lv_indev_t *indev, lv_indev_data_t *data)
+{
+    display_lvgl_t *context = (display_lvgl_t *)lv_indev_get_user_data(indev);
+    uint16_t touch_x[1] = {0U};
+    uint16_t touch_y[1] = {0U};
+    uint8_t touch_count = 0U;
+    bool is_pressed;
+
+    if ((context == NULL) || (context->touch_handle == NULL) || (data == NULL)) {
+        data->state = LV_INDEV_STATE_RELEASED;
+        return;
+    }
+
+    (void)esp_lcd_touch_read_data(context->touch_handle);
+    is_pressed = esp_lcd_touch_get_coordinates(context->touch_handle,
+                                               touch_x,
+                                               touch_y,
+                                               NULL,
+                                               &touch_count,
+                                               1U);
+
+    if (is_pressed && (touch_count > 0U)) {
+        data->point.x = touch_x[0];
+        data->point.y = touch_y[0];
+        data->state = LV_INDEV_STATE_PRESSED;
+    } else {
+        data->state = LV_INDEV_STATE_RELEASED;
+    }
+}
+
+static void increase_lvgl_tick(void *arg)
+{
+    LV_UNUSED(arg);
+    lv_tick_inc(ESP32TOUCH_LVGL_TICK_PERIOD_MS);
+}
+
+static void display_lvgl_task(void *arg)
+{
+    display_lvgl_t *context = (display_lvgl_t *)arg;
+    const uint32_t scheduler_period_ms = 1000U / CONFIG_FREERTOS_HZ;
+
+    ESP_LOGI(TAG, "Starting LVGL task");
+
+    for (;;) {
+        uint32_t wait_ms = ESP32TOUCH_LVGL_TASK_MAX_DELAY_MS;
+
+        if ((context != NULL) &&
+            (context->display != NULL) &&
+            (lvgl_lock_acquire(ESP32TOUCH_LVGL_LOCK_TIMEOUT_MS) == ESP_OK)) {
+            wait_ms = lv_timer_handler();
+            ui_manager_try_load_pending_screen();
+            (void)lvgl_lock_release();
+        }
+
+        if (wait_ms < scheduler_period_ms) {
+            wait_ms = scheduler_period_ms;
+        }
+        if (wait_ms < ESP32TOUCH_LVGL_TASK_MIN_DELAY_MS) {
+            wait_ms = ESP32TOUCH_LVGL_TASK_MIN_DELAY_MS;
+        }
+        if (wait_ms > ESP32TOUCH_LVGL_TASK_MAX_DELAY_MS) {
+            wait_ms = ESP32TOUCH_LVGL_TASK_MAX_DELAY_MS;
+        }
+
+        vTaskDelay(pdMS_TO_TICKS(wait_ms));
+    }
+}
+
+esp_err_t display_lvgl_deinit(display_lvgl_t *lvgl_port)
+{
+    if (lvgl_port == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (lvgl_port->task_handle != NULL) {
+        vTaskDelete(lvgl_port->task_handle);
+        lvgl_port->task_handle = NULL;
+    }
+
+    if (lvgl_port->tick_timer != NULL) {
+        (void)esp_timer_stop(lvgl_port->tick_timer);
+        (void)esp_timer_delete(lvgl_port->tick_timer);
+        lvgl_port->tick_timer = NULL;
+    }
+
+    if (lvgl_port->touch_input_device != NULL) {
+        lv_indev_delete(lvgl_port->touch_input_device);
+        lvgl_port->touch_input_device = NULL;
+    }
+
+    if (lvgl_port->display != NULL) {
+        lv_display_delete(lvgl_port->display);
+        lvgl_port->display = NULL;
+    }
+
+    if (lvgl_port->draw_buffer_primary != NULL) {
+        free(lvgl_port->draw_buffer_primary);
+        lvgl_port->draw_buffer_primary = NULL;
+    }
+
+    if (lvgl_port->draw_buffer_secondary != NULL) {
+        free(lvgl_port->draw_buffer_secondary);
+        lvgl_port->draw_buffer_secondary = NULL;
+    }
+
+    lvgl_port->draw_buffer_size_bytes = 0U;
+    lvgl_port->panel_handle = NULL;
+    lvgl_port->io_handle = NULL;
+    lvgl_port->touch_handle = NULL;
+    lvgl_port->is_initialized = false;
+    return ESP_OK;
+}
+
+esp_err_t display_lvgl_init(const bsp_display_t *bsp_display,
+                            const bsp_touch_t *bsp_touch,
+                            display_lvgl_t *lvgl_port)
+{
+    esp_err_t result;
+    BaseType_t task_result;
+    const esp_timer_create_args_t tick_timer_args = {
+        .callback = increase_lvgl_tick,
+        .name = "lvgl_tick",
+    };
+    const esp_lcd_panel_io_callbacks_t panel_callbacks = {
+        .on_color_trans_done = notify_lvgl_flush_ready,
+    };
+
+    if ((bsp_display == NULL) || (lvgl_port == NULL)) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    *lvgl_port = (display_lvgl_t) {0};
+    lvgl_port->panel_handle = bsp_display->panel_handle;
+    lvgl_port->io_handle = bsp_display->io_handle;
+    lvgl_port->touch_handle = ((bsp_touch != NULL) ? bsp_touch->touch_handle : NULL);
+    lvgl_port->applied_rotation = LV_DISPLAY_ROTATION_180;
+
+    result = lvgl_lock_init();
+    if (result != ESP_OK) {
+        return result;
+    }
+
+    ESP_LOGI(TAG, "Initialize LVGL");
+    lv_init();
+
+    lvgl_port->display = lv_display_create(ESP32TOUCH_LCD_HORIZONTAL_RESOLUTION,
+                                           ESP32TOUCH_LCD_VERTICAL_RESOLUTION);
+    if (lvgl_port->display == NULL) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    lvgl_port->draw_buffer_size_bytes = (size_t)ESP32TOUCH_LCD_HORIZONTAL_RESOLUTION *
+                                        (size_t)ESP32TOUCH_LVGL_DRAW_BUFFER_LINE_COUNT *
+                                        sizeof(lv_color16_t);
+    lvgl_port->draw_buffer_primary = spi_bus_dma_memory_alloc(ESP32TOUCH_LCD_SPI_HOST,
+                                                              lvgl_port->draw_buffer_size_bytes,
+                                                              0U);
+    lvgl_port->draw_buffer_secondary = spi_bus_dma_memory_alloc(ESP32TOUCH_LCD_SPI_HOST,
+                                                                lvgl_port->draw_buffer_size_bytes,
+                                                                0U);
+    /* MISRA boundary note: buffer allocation is constrained to the LVGL/driver integration layer. */
+    if ((lvgl_port->draw_buffer_primary == NULL) || (lvgl_port->draw_buffer_secondary == NULL)) {
+        (void)display_lvgl_deinit(lvgl_port);
+        return ESP_ERR_NO_MEM;
+    }
+
+    lv_display_set_buffers(lvgl_port->display,
+                           lvgl_port->draw_buffer_primary,
+                           lvgl_port->draw_buffer_secondary,
+                           lvgl_port->draw_buffer_size_bytes,
+                           LV_DISPLAY_RENDER_MODE_PARTIAL);
+    lv_display_set_color_format(lvgl_port->display, LV_COLOR_FORMAT_RGB565);
+    lv_display_set_user_data(lvgl_port->display, lvgl_port);
+    lv_display_set_flush_cb(lvgl_port->display, display_lvgl_flush_cb);
+
+    result = apply_display_rotation(lvgl_port, lvgl_port->display);
+    if (result != ESP_OK) {
+        (void)display_lvgl_deinit(lvgl_port);
+        return result;
+    }
+
+    result = esp_timer_create(&tick_timer_args, &lvgl_port->tick_timer);
+    if (result != ESP_OK) {
+        (void)display_lvgl_deinit(lvgl_port);
+        return result;
+    }
+
+    result = esp_timer_start_periodic(lvgl_port->tick_timer, ESP32TOUCH_LVGL_TICK_PERIOD_MS * 1000U);
+    if (result != ESP_OK) {
+        (void)display_lvgl_deinit(lvgl_port);
+        return result;
+    }
+
+    result = esp_lcd_panel_io_register_event_callbacks(lvgl_port->io_handle,
+                                                       &panel_callbacks,
+                                                       lvgl_port->display);
+    if (result != ESP_OK) {
+        (void)display_lvgl_deinit(lvgl_port);
+        return result;
+    }
+
+    if (lvgl_port->touch_handle != NULL) {
+        lvgl_port->touch_input_device = lv_indev_create();
+        if (lvgl_port->touch_input_device == NULL) {
+            (void)display_lvgl_deinit(lvgl_port);
+            return ESP_ERR_NO_MEM;
+        }
+
+        lv_indev_set_type(lvgl_port->touch_input_device, LV_INDEV_TYPE_POINTER);
+        lv_indev_set_display(lvgl_port->touch_input_device, lvgl_port->display);
+        lv_indev_set_user_data(lvgl_port->touch_input_device, lvgl_port);
+        lv_indev_set_read_cb(lvgl_port->touch_input_device, display_lvgl_touch_cb);
+    }
+
+    task_result = xTaskCreatePinnedToCore(display_lvgl_task,
+                                          "lvgl",
+                                          ESP32TOUCH_LVGL_TASK_STACK_SIZE_BYTES,
+                                          lvgl_port,
+                                          ESP32TOUCH_LVGL_TASK_PRIORITY,
+                                          &lvgl_port->task_handle,
+                                          (BaseType_t)ESP32TOUCH_LVGL_TASK_CORE_ID);
+    if (task_result != pdPASS) {
+        (void)display_lvgl_deinit(lvgl_port);
+        return ESP_FAIL;
+    }
+
+    lvgl_port->is_initialized = true;
+    return ESP_OK;
+}

--- a/main/ui/components/ui_nav_bar.c
+++ b/main/ui/components/ui_nav_bar.c
@@ -1,0 +1,266 @@
+#include "ui/components/ui_nav_bar.h"
+
+#include <string.h>
+
+#include "esp_log.h"
+
+#include "lvgl.h"
+
+static const char *TAG = "ui_nav_bar";
+
+enum
+{
+    UI_NAV_BAR_HEIGHT = 42,
+    UI_NAV_MORE_PANEL_WIDTH = 140,
+    UI_NAV_MORE_PANEL_HEIGHT = 124
+};
+
+typedef struct
+{
+    ui_nav_bar_t *nav_bar;
+    ui_screen_id_t screen_id;
+} nav_button_context_t;
+
+static nav_button_context_t s_dashboard_context;
+static nav_button_context_t s_recipe_context;
+static nav_button_context_t s_vision_context;
+static nav_button_context_t s_alarms_context;
+static nav_button_context_t s_statistics_context;
+static nav_button_context_t s_calibration_context;
+static nav_button_context_t s_maintenance_context;
+static nav_button_context_t s_login_context;
+static ui_nav_bar_t *s_open_more_nav_bar;
+
+static bool is_more_screen(ui_screen_id_t screen_id)
+{
+    return (screen_id == UI_SCREEN_STATISTICS) ||
+           (screen_id == UI_SCREEN_CALIBRATION) ||
+           (screen_id == UI_SCREEN_MAINTENANCE) ||
+           (screen_id == UI_SCREEN_LOGIN);
+}
+
+static void set_button_active_style(lv_obj_t *button, bool is_active)
+{
+    if (button == NULL) {
+        return;
+    }
+
+    if (is_active) {
+        lv_obj_set_style_bg_color(button, lv_palette_main(LV_PALETTE_INDIGO), 0);
+        lv_obj_set_style_text_color(button, lv_color_white(), 0);
+    } else {
+        lv_obj_set_style_bg_color(button, lv_color_hex(0x1A2438), 0);
+        lv_obj_set_style_text_color(button, lv_palette_main(LV_PALETTE_GREY), 0);
+    }
+}
+
+static void hide_more_panel(ui_nav_bar_t *nav_bar)
+{
+    if ((nav_bar != NULL) && (nav_bar->more_panel != NULL)) {
+        lv_obj_add_flag(nav_bar->more_panel, LV_OBJ_FLAG_HIDDEN);
+        if (s_open_more_nav_bar == nav_bar) {
+            s_open_more_nav_bar = NULL;
+        }
+    }
+}
+
+static void show_more_panel(ui_nav_bar_t *nav_bar)
+{
+    if ((nav_bar != NULL) && (nav_bar->more_panel != NULL)) {
+        lv_obj_remove_flag(nav_bar->more_panel, LV_OBJ_FLAG_HIDDEN);
+        s_open_more_nav_bar = nav_bar;
+    }
+}
+
+static void nav_button_event_cb(lv_event_t *event)
+{
+    esp_err_t result;
+    nav_button_context_t *context = (nav_button_context_t *)lv_event_get_user_data(event);
+
+    if (context == NULL) {
+        return;
+    }
+
+    hide_more_panel(context->nav_bar);
+    result = ui_manager_show(context->screen_id);
+    if (result != ESP_OK) {
+        ESP_LOGW(TAG,
+                 "Navigation denied/failed for screen_id=%d (err=%s)",
+                 (int)context->screen_id,
+                 esp_err_to_name(result));
+    }
+}
+
+static void nav_more_button_event_cb(lv_event_t *event)
+{
+    ui_nav_bar_t *nav_bar = (ui_nav_bar_t *)lv_event_get_user_data(event);
+
+    if ((nav_bar == NULL) || (nav_bar->more_panel == NULL)) {
+        return;
+    }
+
+    if (lv_obj_has_flag(nav_bar->more_panel, LV_OBJ_FLAG_HIDDEN)) {
+        show_more_panel(nav_bar);
+    } else {
+        hide_more_panel(nav_bar);
+    }
+}
+
+static lv_obj_t *create_nav_button(lv_obj_t *parent,
+                                   const char *label_text,
+                                   nav_button_context_t *context,
+                                   lv_event_cb_t event_cb,
+                                   void *user_data)
+{
+    lv_obj_t *button = lv_button_create(parent);
+    lv_obj_t *label = lv_label_create(button);
+
+    lv_obj_set_style_radius(button, 10, 0);
+    lv_obj_set_style_bg_color(button, lv_color_hex(0x1A2438), 0);
+    lv_obj_set_style_border_width(button, 0, 0);
+    lv_obj_set_style_pad_hor(button, 10, 0);
+    lv_obj_set_style_pad_ver(button, 6, 0);
+    lv_obj_add_flag(button, LV_OBJ_FLAG_SCROLL_ON_FOCUS);
+
+    lv_label_set_text(label, label_text);
+    lv_obj_center(label);
+
+    if (event_cb != NULL) {
+        lv_obj_add_event_cb(button, event_cb, LV_EVENT_CLICKED, (user_data != NULL) ? user_data : context);
+    }
+
+    return button;
+}
+
+static void init_context(nav_button_context_t *context, ui_nav_bar_t *nav_bar, ui_screen_id_t screen_id)
+{
+    if (context != NULL) {
+        context->nav_bar = nav_bar;
+        context->screen_id = screen_id;
+    }
+}
+
+void ui_nav_bar_set_active(ui_nav_bar_t *nav_bar, ui_screen_id_t active_screen)
+{
+    if (nav_bar == NULL) {
+        return;
+    }
+
+    set_button_active_style(nav_bar->button_dashboard, active_screen == UI_SCREEN_MAIN);
+    set_button_active_style(nav_bar->button_recipe, active_screen == UI_SCREEN_RECIPE);
+    set_button_active_style(nav_bar->button_vision, active_screen == UI_SCREEN_VISION_TUNING);
+    set_button_active_style(nav_bar->button_alarms, active_screen == UI_SCREEN_ALARMS);
+    set_button_active_style(nav_bar->button_more, is_more_screen(active_screen));
+}
+
+esp_err_t ui_nav_bar_create(lv_obj_t *parent,
+                            ui_screen_id_t active_screen,
+                            ui_nav_bar_t *nav_bar)
+{
+    lv_obj_t *button;
+
+    if ((parent == NULL) || (nav_bar == NULL)) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    (void)memset(nav_bar, 0, sizeof(*nav_bar));
+
+    nav_bar->root = lv_obj_create(parent);
+    if (nav_bar->root == NULL) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    lv_obj_set_size(nav_bar->root, lv_pct(100), UI_NAV_BAR_HEIGHT);
+    lv_obj_set_style_radius(nav_bar->root, 0, 0);
+    lv_obj_set_style_border_width(nav_bar->root, 0, 0);
+    lv_obj_set_style_bg_color(nav_bar->root, lv_color_hex(0x0E1526), 0);
+    lv_obj_set_style_pad_all(nav_bar->root, 4, 0);
+    lv_obj_set_layout(nav_bar->root, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(nav_bar->root, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(nav_bar->root, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_clear_flag(nav_bar->root, LV_OBJ_FLAG_SCROLLABLE);
+
+    init_context(&s_dashboard_context, nav_bar, UI_SCREEN_MAIN);
+    init_context(&s_recipe_context, nav_bar, UI_SCREEN_RECIPE);
+    init_context(&s_vision_context, nav_bar, UI_SCREEN_VISION_TUNING);
+    init_context(&s_alarms_context, nav_bar, UI_SCREEN_ALARMS);
+    init_context(&s_statistics_context, nav_bar, UI_SCREEN_STATISTICS);
+    init_context(&s_calibration_context, nav_bar, UI_SCREEN_CALIBRATION);
+    init_context(&s_maintenance_context, nav_bar, UI_SCREEN_MAINTENANCE);
+    init_context(&s_login_context, nav_bar, UI_SCREEN_LOGIN);
+
+    nav_bar->button_dashboard = create_nav_button(nav_bar->root, "Dash", &s_dashboard_context, nav_button_event_cb, NULL);
+    nav_bar->button_recipe = create_nav_button(nav_bar->root, "Recipe", &s_recipe_context, nav_button_event_cb, NULL);
+    nav_bar->button_vision = create_nav_button(nav_bar->root, "Vision", &s_vision_context, nav_button_event_cb, NULL);
+    nav_bar->button_alarms = create_nav_button(nav_bar->root, "Alarms", &s_alarms_context, nav_button_event_cb, NULL);
+    nav_bar->button_more = create_nav_button(nav_bar->root, "More", NULL, nav_more_button_event_cb, nav_bar);
+
+    if (!ui_manager_can_access_screen(UI_SCREEN_RECIPE)) {
+        lv_obj_add_flag(nav_bar->button_recipe, LV_OBJ_FLAG_HIDDEN);
+    }
+    if (!ui_manager_can_access_screen(UI_SCREEN_VISION_TUNING)) {
+        lv_obj_add_flag(nav_bar->button_vision, LV_OBJ_FLAG_HIDDEN);
+    }
+    if (!ui_manager_can_access_screen(UI_SCREEN_ALARMS)) {
+        lv_obj_add_flag(nav_bar->button_alarms, LV_OBJ_FLAG_HIDDEN);
+    }
+
+    nav_bar->more_panel = lv_obj_create(parent);
+    if (nav_bar->more_panel == NULL) {
+        ui_nav_bar_destroy(nav_bar);
+        return ESP_ERR_NO_MEM;
+    }
+
+    lv_obj_set_size(nav_bar->more_panel, UI_NAV_MORE_PANEL_WIDTH, UI_NAV_MORE_PANEL_HEIGHT);
+    lv_obj_align(nav_bar->more_panel, LV_ALIGN_BOTTOM_RIGHT, -8, -(UI_NAV_BAR_HEIGHT + 8));
+    lv_obj_set_style_radius(nav_bar->more_panel, 12, 0);
+    lv_obj_set_style_bg_color(nav_bar->more_panel, lv_color_hex(0x162033), 0);
+    lv_obj_set_style_border_width(nav_bar->more_panel, 1, 0);
+    lv_obj_set_style_border_color(nav_bar->more_panel, lv_palette_main(LV_PALETTE_BLUE_GREY), 0);
+    lv_obj_set_style_pad_all(nav_bar->more_panel, 6, 0);
+    lv_obj_set_layout(nav_bar->more_panel, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(nav_bar->more_panel, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(nav_bar->more_panel, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_clear_flag(nav_bar->more_panel, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_flag(nav_bar->more_panel, LV_OBJ_FLAG_HIDDEN);
+
+    button = create_nav_button(nav_bar->more_panel, "Statistics", &s_statistics_context, nav_button_event_cb, NULL);
+    if (!ui_manager_can_access_screen(UI_SCREEN_STATISTICS)) {
+        lv_obj_add_flag(button, LV_OBJ_FLAG_HIDDEN);
+    }
+
+    button = create_nav_button(nav_bar->more_panel, "Calibration", &s_calibration_context, nav_button_event_cb, NULL);
+    if (!ui_manager_can_access_screen(UI_SCREEN_CALIBRATION)) {
+        lv_obj_add_flag(button, LV_OBJ_FLAG_HIDDEN);
+    }
+
+    button = create_nav_button(nav_bar->more_panel, "Maintenance", &s_maintenance_context, nav_button_event_cb, NULL);
+    if (!ui_manager_can_access_screen(UI_SCREEN_MAINTENANCE)) {
+        lv_obj_add_flag(button, LV_OBJ_FLAG_HIDDEN);
+    }
+
+    button = create_nav_button(nav_bar->more_panel, "Login", &s_login_context, nav_button_event_cb, NULL);
+    if (!ui_manager_can_access_screen(UI_SCREEN_LOGIN)) {
+        lv_obj_add_flag(button, LV_OBJ_FLAG_HIDDEN);
+    }
+
+    ui_nav_bar_set_active(nav_bar, active_screen);
+    return ESP_OK;
+}
+
+void ui_nav_bar_destroy(ui_nav_bar_t *nav_bar)
+{
+    if (nav_bar == NULL) {
+        return;
+    }
+
+    if (nav_bar->more_panel != NULL) {
+        lv_obj_delete(nav_bar->more_panel);
+        nav_bar->more_panel = NULL;
+    }
+
+    if (nav_bar->root != NULL) {
+        lv_obj_delete(nav_bar->root);
+        nav_bar->root = NULL;
+    }
+}

--- a/main/ui/screens/screen_main.c
+++ b/main/ui/screens/screen_main.c
@@ -1,0 +1,279 @@
+#include "ui/screens/screen_main.h"
+
+#include <stdbool.h>
+#include <string.h>
+
+#include "application/hmi_state.h"
+#include "config/ui_theme.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "middleware/i18n/i18n_table.h"
+#include "ui/components/ui_status_card.h"
+
+static lv_display_rotation_t get_next_rotation(lv_display_rotation_t rotation)
+{
+    lv_display_rotation_t next_rotation;
+
+    switch (rotation) {
+    case LV_DISPLAY_ROTATION_0:
+        next_rotation = LV_DISPLAY_ROTATION_90;
+        break;
+    case LV_DISPLAY_ROTATION_90:
+        next_rotation = LV_DISPLAY_ROTATION_180;
+        break;
+    case LV_DISPLAY_ROTATION_180:
+        next_rotation = LV_DISPLAY_ROTATION_270;
+        break;
+    case LV_DISPLAY_ROTATION_270:
+    default:
+        next_rotation = LV_DISPLAY_ROTATION_0;
+        break;
+    }
+
+    return next_rotation;
+}
+
+static void rotate_button_event_cb(lv_event_t *event)
+{
+    screen_main_view_t *view = (screen_main_view_t *)lv_event_get_user_data(event);
+
+    if ((view != NULL) && (view->shell.display != NULL)) {
+        view->rotation = get_next_rotation(view->rotation);
+        lv_display_set_rotation(view->shell.display, view->rotation);
+    }
+}
+
+static void set_value_label(lv_obj_t *label, const char *text)
+{
+    if ((label != NULL) && (text != NULL) && (strcmp(lv_label_get_text(label), text) != 0)) {
+        ui_status_card_set_value(label, text);
+    }
+}
+
+static void append_feature_text(char *buffer, size_t buffer_size, const char *feature_name)
+{
+    size_t used_length;
+
+    if ((buffer == NULL) || (buffer_size == 0U) || (feature_name == NULL)) {
+        return;
+    }
+
+    used_length = strlen(buffer);
+    if (used_length >= buffer_size) {
+        return;
+    }
+
+    (void)lv_snprintf(buffer + used_length,
+                      buffer_size - used_length,
+                      "%s%s",
+                      (used_length > 0U) ? ", " : "",
+                      feature_name);
+}
+
+static void build_feature_text(const app_chip_features_t *features, char *buffer, size_t buffer_size)
+{
+    if ((features == NULL) || (buffer == NULL) || (buffer_size == 0U)) {
+        return;
+    }
+
+    buffer[0] = '\0';
+
+    if (features->has_wifi) {
+        append_feature_text(buffer, buffer_size, "WiFi");
+    }
+    if (features->has_ble) {
+        append_feature_text(buffer, buffer_size, "BLE");
+    }
+    if (features->has_classic_bluetooth) {
+        append_feature_text(buffer, buffer_size, "BT");
+    }
+    if (features->has_ieee802154) {
+        append_feature_text(buffer, buffer_size, "802.15.4");
+    }
+    if (features->has_embedded_flash) {
+        append_feature_text(buffer, buffer_size, "EmbFlash");
+    }
+    if (features->has_embedded_psram) {
+        append_feature_text(buffer, buffer_size, "EmbPSRAM");
+    }
+
+    if (buffer[0] == '\0') {
+        (void)lv_snprintf(buffer, buffer_size, "N/A");
+    }
+}
+
+esp_err_t screen_main_create(lv_display_t *display, screen_main_view_t *view)
+{
+    static lv_coord_t column_descriptors[] = {108, 108, LV_GRID_TEMPLATE_LAST};
+    static lv_coord_t row_descriptors[] = {UI_THEME_MAIN_GRID_ROW_H, UI_THEME_MAIN_GRID_ROW_H, LV_GRID_TEMPLATE_LAST};
+    lv_obj_t *grid;
+    lv_obj_t *rotate_button;
+    lv_obj_t *button_label;
+    lv_obj_t *content;
+    lv_obj_t *button_row;
+    char status_text[64];
+    hmi_runtime_state_t state;
+    const char *title = "Dashboard";
+
+    if ((display == NULL) || (view == NULL)) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    (void)memset(view, 0, sizeof(*view));
+    view->rotation = LV_DISPLAY_ROTATION_0;
+
+    if (hmi_state_get(&state) == ESP_OK) {
+        title = i18n_table_get(state.current_language, I18N_KEY_DASHBOARD);
+    }
+    if (ui_shell_create_with_back(display, UI_SCREEN_MAIN, title, true, UI_SCREEN_HOME, &view->shell) != ESP_OK) {
+        return ESP_FAIL;
+    }
+    vTaskDelay(pdMS_TO_TICKS(1));
+
+    (void)lv_snprintf(status_text, sizeof(status_text), "Dashboard  Chip metrics  Role active");
+    ui_shell_set_status_text(&view->shell, status_text);
+
+    content = ui_shell_get_content(&view->shell);
+    if (content == NULL) {
+        ui_shell_destroy(&view->shell);
+        return ESP_FAIL;
+    }
+
+    grid = lv_obj_create(content);
+    lv_obj_set_size(grid, UI_THEME_MAIN_GRID_WIDTH, UI_THEME_MAIN_GRID_HEIGHT);
+    lv_obj_align(grid, LV_ALIGN_TOP_MID, 0, 0);
+    lv_obj_set_style_bg_opa(grid, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(grid, 0, 0);
+    lv_obj_set_style_pad_all(grid, 0, 0);
+    lv_obj_clear_flag(grid, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_grid_dsc_array(grid, column_descriptors, row_descriptors);
+    vTaskDelay(pdMS_TO_TICKS(1));
+
+    view->chip_value_label = ui_status_card_create(grid, "Chip", UI_THEME_MAIN_CARD_WIDTH, UI_THEME_MAIN_CARD_HEIGHT);
+    lv_obj_set_grid_cell(lv_obj_get_parent(view->chip_value_label),
+                         LV_GRID_ALIGN_STRETCH, 0, 1,
+                         LV_GRID_ALIGN_STRETCH, 0, 1);
+    vTaskDelay(pdMS_TO_TICKS(1));
+
+    view->memory_value_label = ui_status_card_create(grid, "Memory", UI_THEME_MAIN_CARD_WIDTH, UI_THEME_MAIN_CARD_HEIGHT);
+    lv_obj_set_grid_cell(lv_obj_get_parent(view->memory_value_label),
+                         LV_GRID_ALIGN_STRETCH, 1, 1,
+                         LV_GRID_ALIGN_STRETCH, 0, 1);
+    vTaskDelay(pdMS_TO_TICKS(1));
+
+    view->system_value_label = ui_status_card_create(grid, "System", UI_THEME_MAIN_CARD_WIDTH, UI_THEME_MAIN_CARD_HEIGHT);
+    lv_obj_set_grid_cell(lv_obj_get_parent(view->system_value_label),
+                         LV_GRID_ALIGN_STRETCH, 0, 1,
+                         LV_GRID_ALIGN_STRETCH, 1, 1);
+    vTaskDelay(pdMS_TO_TICKS(1));
+
+    view->network_value_label = ui_status_card_create(grid, "Network", UI_THEME_MAIN_CARD_WIDTH, UI_THEME_MAIN_CARD_HEIGHT);
+    lv_obj_set_grid_cell(lv_obj_get_parent(view->network_value_label),
+                         LV_GRID_ALIGN_STRETCH, 1, 1,
+                         LV_GRID_ALIGN_STRETCH, 1, 1);
+    vTaskDelay(pdMS_TO_TICKS(1));
+
+    set_value_label(view->chip_value_label, "Loading...");
+    set_value_label(view->memory_value_label, "Loading...");
+    set_value_label(view->system_value_label, "Loading...");
+    set_value_label(view->network_value_label, "Loading...");
+
+    button_row = lv_obj_create(content);
+    lv_obj_set_size(button_row, lv_pct(100), 30);
+    lv_obj_align(button_row, LV_ALIGN_BOTTOM_MID, 0, 0);
+    lv_obj_set_style_bg_opa(button_row, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(button_row, 0, 0);
+    lv_obj_set_style_pad_all(button_row, 0, 0);
+    lv_obj_clear_flag(button_row, LV_OBJ_FLAG_SCROLLABLE);
+
+    rotate_button = lv_button_create(button_row);
+    lv_obj_set_size(rotate_button, UI_THEME_MAIN_BUTTON_WIDTH, UI_THEME_MAIN_BUTTON_HEIGHT);
+    lv_obj_align(rotate_button, LV_ALIGN_RIGHT_MID, -6, 0);
+    lv_obj_set_style_radius(rotate_button, 12, 0);
+    lv_obj_set_style_bg_color(rotate_button, lv_palette_main(LV_PALETTE_INDIGO), 0);
+    lv_obj_add_event_cb(rotate_button, rotate_button_event_cb, LV_EVENT_CLICKED, view);
+
+    button_label = lv_label_create(rotate_button);
+    lv_label_set_text(button_label, LV_SYMBOL_REFRESH " Rotate");
+    lv_obj_center(button_label);
+
+    view->is_created = true;
+    return ESP_OK;
+}
+
+void screen_main_destroy(screen_main_view_t *view)
+{
+    if (view != NULL) {
+        ui_shell_destroy(&view->shell);
+        (void)memset(view, 0, sizeof(*view));
+    }
+}
+
+esp_err_t screen_main_update_status(screen_main_view_t *view, const app_data_snapshot_t *snapshot)
+{
+    char memory_buffer[128];
+    char system_buffer[128];
+    char network_buffer[96];
+    char chip_buffer[160];
+    char temperature_buffer[16];
+    char feature_buffer[64];
+    int16_t whole_temperature;
+    int16_t fractional_temperature;
+    int16_t absolute_temperature;
+
+    if ((view == NULL) || (snapshot == NULL) || !view->is_created) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    build_feature_text(&snapshot->chip_info.features, feature_buffer, sizeof(feature_buffer));
+
+    if (snapshot->runtime_info.temperature_valid) {
+        whole_temperature = (int16_t)(snapshot->runtime_info.temperature_deci_celsius / 10);
+        absolute_temperature = (snapshot->runtime_info.temperature_deci_celsius >= 0)
+                               ? snapshot->runtime_info.temperature_deci_celsius
+                               : (int16_t)(-snapshot->runtime_info.temperature_deci_celsius);
+        fractional_temperature = (int16_t)(absolute_temperature % 10);
+        (void)lv_snprintf(temperature_buffer,
+                          sizeof(temperature_buffer),
+                          "%d.%d C",
+                          whole_temperature,
+                          fractional_temperature);
+    } else {
+        (void)lv_snprintf(temperature_buffer, sizeof(temperature_buffer), "N/A");
+    }
+
+    (void)lv_snprintf(chip_buffer,
+                      sizeof(chip_buffer),
+                      "%s rev %u\nCores: %u\n%s",
+                      snapshot->chip_info.model_name,
+                      (unsigned int)snapshot->chip_info.revision,
+                      (unsigned int)snapshot->chip_info.cpu_core_count,
+                      feature_buffer);
+
+    (void)lv_snprintf(memory_buffer,
+                      sizeof(memory_buffer),
+                      "Flash: %lu MB\nPSRAM: %lu MB\nHeap: %lu KB",
+                      (unsigned long)(snapshot->runtime_info.flash_size_bytes / (1024UL * 1024UL)),
+                      (unsigned long)(snapshot->runtime_info.psram_size_bytes / (1024UL * 1024UL)),
+                      (unsigned long)(snapshot->runtime_info.free_heap_bytes / 1024UL));
+
+    (void)lv_snprintf(system_buffer,
+                      sizeof(system_buffer),
+                      "CPU: %lu MHz\nTemp: %s\nUptime: %lus\nIDF: %s",
+                      (unsigned long)snapshot->runtime_info.cpu_frequency_mhz,
+                      temperature_buffer,
+                      (unsigned long)snapshot->runtime_info.uptime_seconds,
+                      snapshot->chip_info.idf_version);
+
+    (void)lv_snprintf(network_buffer,
+                      sizeof(network_buffer),
+                      "MAC:\n%s",
+                      snapshot->chip_info.mac_address);
+
+    set_value_label(view->chip_value_label, chip_buffer);
+    set_value_label(view->memory_value_label, memory_buffer);
+    set_value_label(view->system_value_label, system_buffer);
+    set_value_label(view->network_value_label, network_buffer);
+
+    return ESP_OK;
+}

--- a/main/ui/ui_manager.c
+++ b/main/ui/ui_manager.c
@@ -3,26 +3,42 @@
 #include <string.h>
 
 #include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/queue.h"
+#include "freertos/task.h"
 
+#include "application/alarm_manager.h"
 #include "application/auth_manager.h"
 #include "application/hmi_state.h"
+#include "application/session_manager.h"
 #include "config/system_config.h"
+#include "config/ui_theme.h"
+#include "middleware/i18n/i18n_table.h"
+#include "ui/components/ui_shell.h"
 #include "ui/screens/screen_alarms.h"
 #include "ui/screens/screen_calibration.h"
 #include "ui/screens/screen_dashboard.h"
+#include "ui/screens/screen_home.h"
 #include "ui/screens/screen_login.h"
 #include "ui/screens/screen_maintenance.h"
 #include "ui/screens/screen_recipe.h"
 #include "ui/screens/screen_main.h"
+#include "ui/screens/screen_splash.h"
 #include "ui/screens/screen_statistics.h"
 #include "ui/screens/screen_vision_tuning.h"
 #include "utils/lvgl_lock.h"
 
 static const char *TAG = "ui_manager";
 
+#define UI_LOADER_QUEUE_SIZE 2U
+#define UI_LOADER_TASK_STACK_SIZE 4096U
+#define UI_LOADER_TASK_PRIORITY 1U
+#define UI_SCREEN_INVALID ((ui_screen_id_t)0xFFU)
+
 typedef struct
 {
     lv_display_t *display;
+    screen_splash_view_t splash_screen;
     screen_dashboard_view_t dashboard_screen;
     screen_recipe_view_t recipe_screen;
     screen_calibration_view_t calibration_screen;
@@ -31,15 +47,24 @@ typedef struct
     screen_alarms_view_t alarms_screen;
     screen_maintenance_view_t maintenance_screen;
     screen_login_view_t login_screen;
+    screen_home_view_t home_screen;
     ui_screen_id_t active_screen;
     bool is_initialized;
 } ui_manager_context_t;
 
 static ui_manager_context_t s_ui_manager;
+static QueueHandle_t s_loader_queue = NULL;
+static TaskHandle_t s_loader_task_handle = NULL;
+static volatile lv_obj_t *s_pending_load_root = NULL;
+static volatile ui_screen_id_t s_pending_screen_id = UI_SCREEN_INVALID;
+
+static void screen_loader_task(void *arg);
 
 static const char *screen_to_name(ui_screen_id_t screen_id)
 {
     switch (screen_id) {
+    case UI_SCREEN_SPLASH:
+        return "splash";
     case UI_SCREEN_MAIN:
         return "main";
     case UI_SCREEN_RECIPE:
@@ -56,6 +81,8 @@ static const char *screen_to_name(ui_screen_id_t screen_id)
         return "maintenance";
     case UI_SCREEN_LOGIN:
         return "login";
+    case UI_SCREEN_HOME:
+        return "home";
     default:
         return "unknown";
     }
@@ -66,6 +93,9 @@ static uint32_t screen_to_permission(ui_screen_id_t screen_id)
     uint32_t permission_mask;
 
     switch (screen_id) {
+    case UI_SCREEN_SPLASH:
+        permission_mask = 0U;
+        break;
     case UI_SCREEN_MAIN:
         permission_mask = HMI_PERMISSION_VIEW_DASHBOARD;
         break;
@@ -88,6 +118,11 @@ static uint32_t screen_to_permission(ui_screen_id_t screen_id)
         permission_mask = HMI_PERMISSION_HARDWARE_TEST;
         break;
     case UI_SCREEN_LOGIN:
+        permission_mask = 0U;
+        break;
+    case UI_SCREEN_HOME:
+        permission_mask = HMI_PERMISSION_VIEW_DASHBOARD;
+        break;
     default:
         permission_mask = 0U;
         break;
@@ -98,21 +133,60 @@ static uint32_t screen_to_permission(ui_screen_id_t screen_id)
 
 esp_err_t ui_manager_init(lv_display_t *display)
 {
+    BaseType_t task_result;
+
     if (display == NULL) {
         return ESP_ERR_INVALID_ARG;
     }
 
     (void)memset(&s_ui_manager, 0, sizeof(s_ui_manager));
     s_ui_manager.display = display;
-    s_ui_manager.active_screen = UI_SCREEN_MAIN;
+    s_ui_manager.active_screen = UI_SCREEN_LOGIN;
     s_ui_manager.is_initialized = true;
 
+    s_pending_load_root = NULL;
+    s_pending_screen_id = UI_SCREEN_INVALID;
+
+    s_loader_queue = xQueueCreate(UI_LOADER_QUEUE_SIZE, sizeof(ui_screen_id_t));
+    if (s_loader_queue == NULL) {
+        ESP_LOGE(TAG, "Failed to create loader queue");
+        return ESP_ERR_NO_MEM;
+    }
+
+    task_result = xTaskCreatePinnedToCore(
+        screen_loader_task,
+        "screen_loader",
+        UI_LOADER_TASK_STACK_SIZE,
+        NULL,
+        UI_LOADER_TASK_PRIORITY,
+        &s_loader_task_handle,
+        ESP32TOUCH_APP_TASK_CORE_ID);
+
+    if (task_result != pdPASS) {
+        vQueueDelete(s_loader_queue);
+        s_loader_queue = NULL;
+        ESP_LOGE(TAG, "Failed to create loader task");
+        return ESP_ERR_NO_MEM;
+    }
+
+    ESP_LOGI(TAG, "UI manager initialized with async screen loader on core %d", ESP32TOUCH_APP_TASK_CORE_ID);
     return ESP_OK;
 }
 
 void ui_manager_deinit(void)
 {
+    if (s_loader_task_handle != NULL) {
+        vTaskDelete(s_loader_task_handle);
+        s_loader_task_handle = NULL;
+    }
+
+    if (s_loader_queue != NULL) {
+        vQueueDelete(s_loader_queue);
+        s_loader_queue = NULL;
+    }
+
     if (lvgl_lock_acquire(ESP32TOUCH_LVGL_LOCK_TIMEOUT_MS) == ESP_OK) {
+        screen_splash_destroy(&s_ui_manager.splash_screen);
         screen_dashboard_destroy(&s_ui_manager.dashboard_screen);
         screen_recipe_destroy(&s_ui_manager.recipe_screen);
         screen_calibration_destroy(&s_ui_manager.calibration_screen);
@@ -121,6 +195,7 @@ void ui_manager_deinit(void)
         screen_alarms_destroy(&s_ui_manager.alarms_screen);
         screen_maintenance_destroy(&s_ui_manager.maintenance_screen);
         screen_login_destroy(&s_ui_manager.login_screen);
+        screen_home_destroy(&s_ui_manager.home_screen);
         (void)lvgl_lock_release();
     }
 
@@ -136,12 +211,129 @@ bool ui_manager_can_access_screen(ui_screen_id_t screen_id)
 {
     const uint32_t permission_mask = screen_to_permission(screen_id);
 
-    if (screen_id == UI_SCREEN_LOGIN) {
+    if ((screen_id == UI_SCREEN_LOGIN) || (screen_id == UI_SCREEN_SPLASH)) {
         return true;
     }
 
     return auth_manager_has_permission(permission_mask);
 }
+
+static bool is_screen_created(ui_screen_id_t screen_id)
+{
+    switch (screen_id) {
+    case UI_SCREEN_SPLASH:
+        return s_ui_manager.splash_screen.is_created;
+    case UI_SCREEN_MAIN:
+        return s_ui_manager.dashboard_screen.is_created;
+    case UI_SCREEN_RECIPE:
+        return s_ui_manager.recipe_screen.is_created;
+    case UI_SCREEN_CALIBRATION:
+        return s_ui_manager.calibration_screen.is_created;
+    case UI_SCREEN_VISION_TUNING:
+        return s_ui_manager.vision_tuning_screen.is_created;
+    case UI_SCREEN_STATISTICS:
+        return s_ui_manager.statistics_screen.is_created;
+    case UI_SCREEN_ALARMS:
+        return s_ui_manager.alarms_screen.is_created;
+    case UI_SCREEN_MAINTENANCE:
+        return s_ui_manager.maintenance_screen.is_created;
+    case UI_SCREEN_LOGIN:
+        return s_ui_manager.login_screen.is_created;
+    case UI_SCREEN_HOME:
+        return s_ui_manager.home_screen.is_created;
+    default:
+        return false;
+    }
+}
+
+static lv_obj_t *get_screen_root(ui_screen_id_t screen_id)
+{
+    switch (screen_id) {
+    case UI_SCREEN_SPLASH:
+        return s_ui_manager.splash_screen.shell.root;
+    case UI_SCREEN_MAIN:
+        return s_ui_manager.dashboard_screen.shell.root;
+    case UI_SCREEN_RECIPE:
+        return s_ui_manager.recipe_screen.shell.root;
+    case UI_SCREEN_CALIBRATION:
+        return s_ui_manager.calibration_screen.shell.root;
+    case UI_SCREEN_VISION_TUNING:
+        return s_ui_manager.vision_tuning_screen.shell.root;
+    case UI_SCREEN_STATISTICS:
+        return s_ui_manager.statistics_screen.shell.root;
+    case UI_SCREEN_ALARMS:
+        return s_ui_manager.alarms_screen.shell.root;
+    case UI_SCREEN_MAINTENANCE:
+        return s_ui_manager.maintenance_screen.shell.root;
+    case UI_SCREEN_LOGIN:
+        return s_ui_manager.login_screen.shell.root;
+    case UI_SCREEN_HOME:
+        return s_ui_manager.home_screen.shell.root;
+    default:
+        return NULL;
+    }
+}
+
+static esp_err_t create_screen_if_needed(ui_screen_id_t screen_id, lv_obj_t **root_object);
+
+static void screen_loader_task(void *arg)
+{
+    ui_screen_id_t screen_id;
+    lv_obj_t *root_object = NULL;
+    esp_err_t result;
+
+    (void)arg;
+    ESP_LOGI(TAG, "Screen loader task started on core %d", xPortGetCoreID());
+
+    for (;;) {
+        if (xQueueReceive(s_loader_queue, &screen_id, portMAX_DELAY) == pdTRUE) {
+            ESP_LOGI(TAG, "Loader: creating screen_id=%d (%s)", (int)screen_id, screen_to_name(screen_id));
+
+            result = lvgl_lock_acquire(ESP32TOUCH_LVGL_LOCK_TIMEOUT_MS);
+            if (result != ESP_OK) {
+                ESP_LOGW(TAG, "Loader: failed to acquire lock for screen_id=%d", (int)screen_id);
+                continue;
+            }
+
+            root_object = NULL;
+            result = create_screen_if_needed(screen_id, &root_object);
+
+            if ((result == ESP_OK) && (root_object != NULL)) {
+                s_pending_load_root = root_object;
+                s_pending_screen_id = screen_id;
+                ESP_LOGI(TAG, "Loader: screen_id=%d ready, root=%p", (int)screen_id, (void *)root_object);
+            } else {
+                ESP_LOGE(TAG, "Loader: failed to create screen_id=%d, err=%s", (int)screen_id, esp_err_to_name(result));
+            }
+
+            (void)lvgl_lock_release();
+        }
+    }
+}
+
+void ui_manager_try_load_pending_screen(void)
+{
+    lv_obj_t *root_object;
+    ui_screen_id_t screen_id;
+
+    if (s_pending_load_root == NULL) {
+        return;
+    }
+
+    root_object = (lv_obj_t *)s_pending_load_root;
+    screen_id = s_pending_screen_id;
+
+    s_pending_load_root = NULL;
+    s_pending_screen_id = UI_SCREEN_INVALID;
+
+    lv_screen_load(root_object);
+    s_ui_manager.active_screen = screen_id;
+    (void)hmi_state_set_screen((hmi_ui_block_t)screen_id);
+
+    ESP_LOGI(TAG, "LVGL: loaded screen_id=%d (%s), root=%p", (int)screen_id, screen_to_name(screen_id), (void *)root_object);
+}
+
+static esp_err_t create_screen_if_needed(ui_screen_id_t screen_id, lv_obj_t **root_object);
 
 static esp_err_t create_screen_if_needed(ui_screen_id_t screen_id, lv_obj_t **root_object)
 {
@@ -152,53 +344,75 @@ static esp_err_t create_screen_if_needed(ui_screen_id_t screen_id, lv_obj_t **ro
     }
 
     switch (screen_id) {
+    case UI_SCREEN_SPLASH:
+        if (!s_ui_manager.splash_screen.is_created) {
+            result = screen_splash_create(s_ui_manager.display, &s_ui_manager.splash_screen);
+            vTaskDelay(pdMS_TO_TICKS(1));
+        }
+        *root_object = s_ui_manager.splash_screen.shell.root;
+        break;
     case UI_SCREEN_MAIN:
         if (!s_ui_manager.dashboard_screen.is_created) {
             result = screen_dashboard_create(s_ui_manager.display, &s_ui_manager.dashboard_screen);
+            vTaskDelay(pdMS_TO_TICKS(1));
         }
         *root_object = s_ui_manager.dashboard_screen.shell.root;
         break;
     case UI_SCREEN_RECIPE:
         if (!s_ui_manager.recipe_screen.is_created) {
             result = screen_recipe_create(s_ui_manager.display, &s_ui_manager.recipe_screen);
+            vTaskDelay(pdMS_TO_TICKS(1));
         }
         *root_object = s_ui_manager.recipe_screen.shell.root;
         break;
     case UI_SCREEN_CALIBRATION:
         if (!s_ui_manager.calibration_screen.is_created) {
             result = screen_calibration_create(s_ui_manager.display, &s_ui_manager.calibration_screen);
+            vTaskDelay(pdMS_TO_TICKS(1));
         }
         *root_object = s_ui_manager.calibration_screen.shell.root;
         break;
     case UI_SCREEN_VISION_TUNING:
         if (!s_ui_manager.vision_tuning_screen.is_created) {
             result = screen_vision_tuning_create(s_ui_manager.display, &s_ui_manager.vision_tuning_screen);
+            vTaskDelay(pdMS_TO_TICKS(1));
         }
         *root_object = s_ui_manager.vision_tuning_screen.shell.root;
         break;
     case UI_SCREEN_STATISTICS:
         if (!s_ui_manager.statistics_screen.is_created) {
             result = screen_statistics_create(s_ui_manager.display, &s_ui_manager.statistics_screen);
+            vTaskDelay(pdMS_TO_TICKS(1));
         }
         *root_object = s_ui_manager.statistics_screen.shell.root;
         break;
     case UI_SCREEN_ALARMS:
         if (!s_ui_manager.alarms_screen.is_created) {
             result = screen_alarms_create(s_ui_manager.display, &s_ui_manager.alarms_screen);
+            vTaskDelay(pdMS_TO_TICKS(1));
         }
         *root_object = s_ui_manager.alarms_screen.shell.root;
         break;
     case UI_SCREEN_MAINTENANCE:
         if (!s_ui_manager.maintenance_screen.is_created) {
             result = screen_maintenance_create(s_ui_manager.display, &s_ui_manager.maintenance_screen);
+            vTaskDelay(pdMS_TO_TICKS(1));
         }
         *root_object = s_ui_manager.maintenance_screen.shell.root;
         break;
     case UI_SCREEN_LOGIN:
         if (!s_ui_manager.login_screen.is_created) {
             result = screen_login_create(s_ui_manager.display, &s_ui_manager.login_screen);
+            vTaskDelay(pdMS_TO_TICKS(1));
         }
         *root_object = s_ui_manager.login_screen.shell.root;
+        break;
+    case UI_SCREEN_HOME:
+        if (!s_ui_manager.home_screen.is_created) {
+            result = screen_home_create(s_ui_manager.display, &s_ui_manager.home_screen);
+            vTaskDelay(pdMS_TO_TICKS(1));
+        }
+        *root_object = s_ui_manager.home_screen.shell.root;
         break;
     default:
         result = ESP_ERR_NOT_SUPPORTED;
@@ -207,6 +421,34 @@ static esp_err_t create_screen_if_needed(ui_screen_id_t screen_id, lv_obj_t **ro
     }
 
     return result;
+}
+
+static ui_shell_t *get_current_shell(void)
+{
+    switch (s_ui_manager.active_screen) {
+    case UI_SCREEN_SPLASH:
+        return &s_ui_manager.splash_screen.shell;
+    case UI_SCREEN_MAIN:
+        return &s_ui_manager.dashboard_screen.shell;
+    case UI_SCREEN_RECIPE:
+        return &s_ui_manager.recipe_screen.shell;
+    case UI_SCREEN_CALIBRATION:
+        return &s_ui_manager.calibration_screen.shell;
+    case UI_SCREEN_VISION_TUNING:
+        return &s_ui_manager.vision_tuning_screen.shell;
+    case UI_SCREEN_STATISTICS:
+        return &s_ui_manager.statistics_screen.shell;
+    case UI_SCREEN_ALARMS:
+        return &s_ui_manager.alarms_screen.shell;
+    case UI_SCREEN_MAINTENANCE:
+        return &s_ui_manager.maintenance_screen.shell;
+    case UI_SCREEN_LOGIN:
+        return &s_ui_manager.login_screen.shell;
+    case UI_SCREEN_HOME:
+        return &s_ui_manager.home_screen.shell;
+    default:
+        return NULL;
+    }
 }
 
 esp_err_t ui_manager_show(ui_screen_id_t screen_id)
@@ -227,32 +469,48 @@ esp_err_t ui_manager_show(ui_screen_id_t screen_id)
         return ESP_ERR_INVALID_STATE;
     }
 
-    result = lvgl_lock_acquire(ESP32TOUCH_LVGL_LOCK_TIMEOUT_MS);
-    if (result != ESP_OK) {
-        return result;
-    }
+    session_manager_touch();
 
-    result = create_screen_if_needed(screen_id, &root_object);
-    if ((result != ESP_OK) || (root_object == NULL)) {
+    /* Check if screen is already created */
+    if (is_screen_created(screen_id)) {
+        /* Screen exists: load it directly (synchronous path) */
+        result = lvgl_lock_acquire(ESP32TOUCH_LVGL_LOCK_TIMEOUT_MS);
+        if (result != ESP_OK) {
+            return result;
+        }
+
+        root_object = get_screen_root(screen_id);
+        if (root_object == NULL) {
+            (void)lvgl_lock_release();
+            ESP_LOGE(TAG, "Screen_id=%d created but root is NULL", (int)screen_id);
+            return ESP_ERR_INVALID_STATE;
+        }
+
+        lv_screen_load(root_object);
+        s_ui_manager.active_screen = screen_id;
+        (void)hmi_state_set_screen((hmi_ui_block_t)screen_id);
         (void)lvgl_lock_release();
-        ESP_LOGW(TAG,
-                 "Failed to prepare screen_id=%d (%s), err=%s, root=%p",
+
+        ESP_LOGI(TAG,
+                 "Loaded screen_id=%d (%s), root=%p",
                  (int)screen_id,
                  screen_to_name(screen_id),
-                 esp_err_to_name(result),
                  (void *)root_object);
-        return result;
+    } else {
+        /* Screen not created: post to loader queue (asynchronous path) */
+        if (s_loader_queue == NULL) {
+            ESP_LOGE(TAG, "Loader queue not initialized");
+            return ESP_ERR_INVALID_STATE;
+        }
+
+        if (xQueueSend(s_loader_queue, &screen_id, 0) != pdTRUE) {
+            ESP_LOGW(TAG, "Loader queue full, screen_id=%d not queued", (int)screen_id);
+            return ESP_ERR_NO_MEM;
+        }
+
+        ESP_LOGI(TAG, "Screen_id=%d (%s) queued for async creation", (int)screen_id, screen_to_name(screen_id));
     }
 
-    lv_screen_load(root_object);
-    s_ui_manager.active_screen = screen_id;
-    (void)hmi_state_set_screen((hmi_ui_block_t)screen_id);
-    (void)lvgl_lock_release();
-    ESP_LOGI(TAG,
-             "Loaded screen_id=%d (%s), root=%p",
-             (int)screen_id,
-             screen_to_name(screen_id),
-             (void *)root_object);
     return ESP_OK;
 }
 
@@ -281,4 +539,74 @@ esp_err_t ui_manager_update_system_status(const app_data_snapshot_t *snapshot)
 
     (void)lvgl_lock_release();
     return result;
+}
+
+void ui_manager_update_alarm_banner(void)
+{
+    ui_shell_t *shell;
+    uint32_t crit;
+    uint32_t warn;
+    uint32_t info;
+
+    if (!s_ui_manager.is_initialized) {
+        return;
+    }
+    shell = get_current_shell();
+    if (shell == NULL) {
+        return;
+    }
+    crit = alarm_manager_get_active_count(ALARM_SEVERITY_CRITICAL);
+    warn = alarm_manager_get_active_count(ALARM_SEVERITY_WARNING);
+    info = alarm_manager_get_active_count(ALARM_SEVERITY_INFO);
+    ui_shell_set_alarm_banner(shell, crit, warn, info);
+}
+
+typedef struct
+{
+    lv_obj_t *mbox;
+    uint32_t id;
+} critical_popup_ud_t;
+
+static void critical_alarm_ack_cb(lv_event_t *e)
+{
+    critical_popup_ud_t *ud = (critical_popup_ud_t *)lv_event_get_user_data(e);
+    if (ud != NULL) {
+        (void)alarm_manager_ack(ud->id);
+        if (ud->mbox != NULL) {
+            lv_msgbox_close(ud->mbox);
+        }
+    }
+}
+
+void ui_manager_show_critical_alarm_popup(uint32_t id, const char *message)
+{
+    hmi_runtime_state_t state;
+    hmi_language_t lang = HMI_LANGUAGE_EN;
+    lv_obj_t *mbox;
+    lv_obj_t *ack_btn;
+    char title_buf[32];
+    static critical_popup_ud_t s_popup_ud;
+
+    if (message == NULL) {
+        return;
+    }
+    if (!s_ui_manager.is_initialized) {
+        return;
+    }
+    if (hmi_state_get(&state) == ESP_OK) {
+        lang = state.current_language;
+    }
+    (void)lv_snprintf(title_buf, sizeof(title_buf), "%s", i18n_table_get(lang, I18N_KEY_ALARM_CRITICAL));
+    mbox = lv_msgbox_create(NULL);
+    if (mbox != NULL) {
+        lv_msgbox_add_title(mbox, title_buf);
+        lv_msgbox_add_text(mbox, message);
+        ack_btn = lv_msgbox_add_footer_button(mbox, i18n_table_get(lang, I18N_KEY_ACK));
+        s_popup_ud.mbox = mbox;
+        s_popup_ud.id = id;
+        if (ack_btn != NULL) {
+            lv_obj_add_event_cb(ack_btn, critical_alarm_ack_cb, LV_EVENT_CLICKED, &s_popup_ud);
+        }
+        lv_msgbox_add_close_button(mbox);
+    }
 }

--- a/main/ui/ui_manager.c
+++ b/main/ui/ui_manager.c
@@ -1,0 +1,284 @@
+#include "ui/ui_manager.h"
+
+#include <string.h>
+
+#include "esp_log.h"
+
+#include "application/auth_manager.h"
+#include "application/hmi_state.h"
+#include "config/system_config.h"
+#include "ui/screens/screen_alarms.h"
+#include "ui/screens/screen_calibration.h"
+#include "ui/screens/screen_dashboard.h"
+#include "ui/screens/screen_login.h"
+#include "ui/screens/screen_maintenance.h"
+#include "ui/screens/screen_recipe.h"
+#include "ui/screens/screen_main.h"
+#include "ui/screens/screen_statistics.h"
+#include "ui/screens/screen_vision_tuning.h"
+#include "utils/lvgl_lock.h"
+
+static const char *TAG = "ui_manager";
+
+typedef struct
+{
+    lv_display_t *display;
+    screen_dashboard_view_t dashboard_screen;
+    screen_recipe_view_t recipe_screen;
+    screen_calibration_view_t calibration_screen;
+    screen_vision_tuning_view_t vision_tuning_screen;
+    screen_statistics_view_t statistics_screen;
+    screen_alarms_view_t alarms_screen;
+    screen_maintenance_view_t maintenance_screen;
+    screen_login_view_t login_screen;
+    ui_screen_id_t active_screen;
+    bool is_initialized;
+} ui_manager_context_t;
+
+static ui_manager_context_t s_ui_manager;
+
+static const char *screen_to_name(ui_screen_id_t screen_id)
+{
+    switch (screen_id) {
+    case UI_SCREEN_MAIN:
+        return "main";
+    case UI_SCREEN_RECIPE:
+        return "recipe";
+    case UI_SCREEN_CALIBRATION:
+        return "calibration";
+    case UI_SCREEN_VISION_TUNING:
+        return "vision_tuning";
+    case UI_SCREEN_STATISTICS:
+        return "statistics";
+    case UI_SCREEN_ALARMS:
+        return "alarms";
+    case UI_SCREEN_MAINTENANCE:
+        return "maintenance";
+    case UI_SCREEN_LOGIN:
+        return "login";
+    default:
+        return "unknown";
+    }
+}
+
+static uint32_t screen_to_permission(ui_screen_id_t screen_id)
+{
+    uint32_t permission_mask;
+
+    switch (screen_id) {
+    case UI_SCREEN_MAIN:
+        permission_mask = HMI_PERMISSION_VIEW_DASHBOARD;
+        break;
+    case UI_SCREEN_RECIPE:
+        permission_mask = HMI_PERMISSION_SELECT_RECIPE;
+        break;
+    case UI_SCREEN_CALIBRATION:
+        permission_mask = HMI_PERMISSION_CALIBRATE;
+        break;
+    case UI_SCREEN_VISION_TUNING:
+        permission_mask = HMI_PERMISSION_VIEW_DEFECT_ANALYSIS;
+        break;
+    case UI_SCREEN_STATISTICS:
+        permission_mask = HMI_PERMISSION_VIEW_STATS;
+        break;
+    case UI_SCREEN_ALARMS:
+        permission_mask = HMI_PERMISSION_VIEW_ALARMS;
+        break;
+    case UI_SCREEN_MAINTENANCE:
+        permission_mask = HMI_PERMISSION_HARDWARE_TEST;
+        break;
+    case UI_SCREEN_LOGIN:
+    default:
+        permission_mask = 0U;
+        break;
+    }
+
+    return permission_mask;
+}
+
+esp_err_t ui_manager_init(lv_display_t *display)
+{
+    if (display == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    (void)memset(&s_ui_manager, 0, sizeof(s_ui_manager));
+    s_ui_manager.display = display;
+    s_ui_manager.active_screen = UI_SCREEN_MAIN;
+    s_ui_manager.is_initialized = true;
+
+    return ESP_OK;
+}
+
+void ui_manager_deinit(void)
+{
+    if (lvgl_lock_acquire(ESP32TOUCH_LVGL_LOCK_TIMEOUT_MS) == ESP_OK) {
+        screen_dashboard_destroy(&s_ui_manager.dashboard_screen);
+        screen_recipe_destroy(&s_ui_manager.recipe_screen);
+        screen_calibration_destroy(&s_ui_manager.calibration_screen);
+        screen_vision_tuning_destroy(&s_ui_manager.vision_tuning_screen);
+        screen_statistics_destroy(&s_ui_manager.statistics_screen);
+        screen_alarms_destroy(&s_ui_manager.alarms_screen);
+        screen_maintenance_destroy(&s_ui_manager.maintenance_screen);
+        screen_login_destroy(&s_ui_manager.login_screen);
+        (void)lvgl_lock_release();
+    }
+
+    (void)memset(&s_ui_manager, 0, sizeof(s_ui_manager));
+}
+
+ui_screen_id_t ui_manager_get_active_screen(void)
+{
+    return s_ui_manager.active_screen;
+}
+
+bool ui_manager_can_access_screen(ui_screen_id_t screen_id)
+{
+    const uint32_t permission_mask = screen_to_permission(screen_id);
+
+    if (screen_id == UI_SCREEN_LOGIN) {
+        return true;
+    }
+
+    return auth_manager_has_permission(permission_mask);
+}
+
+static esp_err_t create_screen_if_needed(ui_screen_id_t screen_id, lv_obj_t **root_object)
+{
+    esp_err_t result = ESP_OK;
+
+    if (root_object == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    switch (screen_id) {
+    case UI_SCREEN_MAIN:
+        if (!s_ui_manager.dashboard_screen.is_created) {
+            result = screen_dashboard_create(s_ui_manager.display, &s_ui_manager.dashboard_screen);
+        }
+        *root_object = s_ui_manager.dashboard_screen.shell.root;
+        break;
+    case UI_SCREEN_RECIPE:
+        if (!s_ui_manager.recipe_screen.is_created) {
+            result = screen_recipe_create(s_ui_manager.display, &s_ui_manager.recipe_screen);
+        }
+        *root_object = s_ui_manager.recipe_screen.shell.root;
+        break;
+    case UI_SCREEN_CALIBRATION:
+        if (!s_ui_manager.calibration_screen.is_created) {
+            result = screen_calibration_create(s_ui_manager.display, &s_ui_manager.calibration_screen);
+        }
+        *root_object = s_ui_manager.calibration_screen.shell.root;
+        break;
+    case UI_SCREEN_VISION_TUNING:
+        if (!s_ui_manager.vision_tuning_screen.is_created) {
+            result = screen_vision_tuning_create(s_ui_manager.display, &s_ui_manager.vision_tuning_screen);
+        }
+        *root_object = s_ui_manager.vision_tuning_screen.shell.root;
+        break;
+    case UI_SCREEN_STATISTICS:
+        if (!s_ui_manager.statistics_screen.is_created) {
+            result = screen_statistics_create(s_ui_manager.display, &s_ui_manager.statistics_screen);
+        }
+        *root_object = s_ui_manager.statistics_screen.shell.root;
+        break;
+    case UI_SCREEN_ALARMS:
+        if (!s_ui_manager.alarms_screen.is_created) {
+            result = screen_alarms_create(s_ui_manager.display, &s_ui_manager.alarms_screen);
+        }
+        *root_object = s_ui_manager.alarms_screen.shell.root;
+        break;
+    case UI_SCREEN_MAINTENANCE:
+        if (!s_ui_manager.maintenance_screen.is_created) {
+            result = screen_maintenance_create(s_ui_manager.display, &s_ui_manager.maintenance_screen);
+        }
+        *root_object = s_ui_manager.maintenance_screen.shell.root;
+        break;
+    case UI_SCREEN_LOGIN:
+        if (!s_ui_manager.login_screen.is_created) {
+            result = screen_login_create(s_ui_manager.display, &s_ui_manager.login_screen);
+        }
+        *root_object = s_ui_manager.login_screen.shell.root;
+        break;
+    default:
+        result = ESP_ERR_NOT_SUPPORTED;
+        *root_object = NULL;
+        break;
+    }
+
+    return result;
+}
+
+esp_err_t ui_manager_show(ui_screen_id_t screen_id)
+{
+    esp_err_t result;
+    lv_obj_t *root_object = NULL;
+
+    if (!s_ui_manager.is_initialized || (s_ui_manager.display == NULL)) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    if (!ui_manager_can_access_screen(screen_id)) {
+        ESP_LOGW(TAG,
+                 "Access denied for screen_id=%d (%s), role=%d",
+                 (int)screen_id,
+                 screen_to_name(screen_id),
+                 (int)auth_manager_get_role());
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    result = lvgl_lock_acquire(ESP32TOUCH_LVGL_LOCK_TIMEOUT_MS);
+    if (result != ESP_OK) {
+        return result;
+    }
+
+    result = create_screen_if_needed(screen_id, &root_object);
+    if ((result != ESP_OK) || (root_object == NULL)) {
+        (void)lvgl_lock_release();
+        ESP_LOGW(TAG,
+                 "Failed to prepare screen_id=%d (%s), err=%s, root=%p",
+                 (int)screen_id,
+                 screen_to_name(screen_id),
+                 esp_err_to_name(result),
+                 (void *)root_object);
+        return result;
+    }
+
+    lv_screen_load(root_object);
+    s_ui_manager.active_screen = screen_id;
+    (void)hmi_state_set_screen((hmi_ui_block_t)screen_id);
+    (void)lvgl_lock_release();
+    ESP_LOGI(TAG,
+             "Loaded screen_id=%d (%s), root=%p",
+             (int)screen_id,
+             screen_to_name(screen_id),
+             (void *)root_object);
+    return ESP_OK;
+}
+
+esp_err_t ui_manager_update_system_status(const app_data_snapshot_t *snapshot)
+{
+    esp_err_t result;
+
+    if (snapshot == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!s_ui_manager.is_initialized) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    result = lvgl_lock_acquire(ESP32TOUCH_LVGL_LOCK_TIMEOUT_MS);
+    if (result != ESP_OK) {
+        return result;
+    }
+
+    if (s_ui_manager.active_screen == UI_SCREEN_MAIN) {
+        result = screen_dashboard_update(&s_ui_manager.dashboard_screen, snapshot);
+    } else {
+        result = ESP_OK;
+    }
+
+    (void)lvgl_lock_release();
+    return result;
+}

--- a/main/ui/ui_manager.h
+++ b/main/ui/ui_manager.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <stdbool.h>
+
+#include "esp_err.h"
+#include "lvgl.h"
+
+#include "application/data_manager.h"
+
+typedef enum
+{
+    UI_SCREEN_SPLASH = 0,
+    UI_SCREEN_MAIN,
+    UI_SCREEN_RECIPE,
+    UI_SCREEN_CALIBRATION,
+    UI_SCREEN_VISION_TUNING,
+    UI_SCREEN_STATISTICS,
+    UI_SCREEN_ALARMS,
+    UI_SCREEN_MAINTENANCE,
+    UI_SCREEN_LOGIN,
+    UI_SCREEN_HOME
+} ui_screen_id_t;
+
+esp_err_t ui_manager_init(lv_display_t *display);
+esp_err_t ui_manager_show(ui_screen_id_t screen_id);
+void ui_manager_deinit(void);
+ui_screen_id_t ui_manager_get_active_screen(void);
+bool ui_manager_can_access_screen(ui_screen_id_t screen_id);
+esp_err_t ui_manager_update_system_status(const app_data_snapshot_t *snapshot);
+void ui_manager_update_alarm_banner(void);
+void ui_manager_show_critical_alarm_popup(uint32_t id, const char *message);
+void ui_manager_try_load_pending_screen(void);

--- a/main/utils/lvgl_lock.c
+++ b/main/utils/lvgl_lock.c
@@ -1,0 +1,36 @@
+#include "utils/lvgl_lock.h"
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+
+static SemaphoreHandle_t s_lvgl_mutex;
+static StaticSemaphore_t s_lvgl_mutex_buffer;
+
+esp_err_t lvgl_lock_init(void)
+{
+    if (s_lvgl_mutex == NULL) {
+        // LVGL input callbacks can synchronously call code paths that re-enter UI APIs.
+        // A recursive mutex avoids self-deadlock when the same task acquires the lock again.
+        s_lvgl_mutex = xSemaphoreCreateRecursiveMutexStatic(&s_lvgl_mutex_buffer);
+    }
+
+    return (s_lvgl_mutex != NULL) ? ESP_OK : ESP_ERR_NO_MEM;
+}
+
+esp_err_t lvgl_lock_acquire(uint32_t timeout_ms)
+{
+    if (s_lvgl_mutex == NULL) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    return (xSemaphoreTakeRecursive(s_lvgl_mutex, pdMS_TO_TICKS(timeout_ms)) == pdTRUE) ? ESP_OK : ESP_ERR_TIMEOUT;
+}
+
+esp_err_t lvgl_lock_release(void)
+{
+    if (s_lvgl_mutex == NULL) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    return (xSemaphoreGiveRecursive(s_lvgl_mutex) == pdTRUE) ? ESP_OK : ESP_FAIL;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new FreeRTOS tasks/queues and a recursive LVGL mutex, which can affect UI responsiveness and introduce concurrency edge cases if lock/loader interactions are wrong.
> 
> **Overview**
> **Improves UI navigation responsiveness** by adding a recursive `lvgl_lock` and an asynchronous screen creation pipeline in `ui_manager` (queue + loader task), with the LVGL task periodically applying any pending `lv_screen_load` via `ui_manager_try_load_pending_screen()`.
> 
> **Adds role/permission-gated navigation**: introduces `auth_manager` permission checks, maps screens to permission masks in `ui_manager_can_access_screen()`, and updates `ui_nav_bar` to hide buttons/screens the current role can’t access (including a "More" flyout).
> 
> Also adds a new `screen_main` implementation (status cards + runtime rotation button) and a `display_lvgl` port that wires LVGL flush/touch callbacks, applies panel rotation to match LVGL rotation, and centralizes LVGL task timing/locking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81b0d5b6b8f5c09f8294d0393a878cc5dc97e64f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->